### PR TITLE
Remove mentions to missing "old" experiment config folder in markdown…

### DIFF
--- a/configs/experiment/README.md
+++ b/configs/experiment/README.md
@@ -5,7 +5,6 @@ cifar/         CIFAR-10, both sequential and 2d
 convnext/      ImageNet + ConvNext variants (S4ND paper)
 forecasting/   Monash, ARIMA synthetics, datasets from the Informer paper
 lra/           Long Range Arena
-old/           Deprecated experiment configs (e.g. from original S4 paper that have been improved)
 progres/       Progressive Resizing (S4ND paper)
 sc/            Speech Commands
 segmentation/  Segmentation experiments (preliminary)

--- a/models/s4/experiments.md
+++ b/models/s4/experiments.md
@@ -62,11 +62,6 @@ The original S4 paper used a smaller 10-way classification task used in [prior](
 
 This version can be toggled either with `dataset=sc dataset.all_classes=false` or `dataset=sc10`.
 
-The original S4 config can be run using V1 of this code using
-```
-python -m train experiment=old/s4-sc
-```
-
 ## WikiText-103
 
 V3 re-trained the WikiText-103 experiment with the latest model and a larger context size.


### PR DESCRIPTION
Removes all the mentions I could find to a `config/experiment/old` folder that appears to never have been released in the public github repo (See issue https://github.com/state-spaces/s4/issues/130).

Proposed edits should avoid confusion of future users and contributors.